### PR TITLE
fix: add smooth scroll-to-top on FiscalAura logo click (closes #4)

### DIFF
--- a/src/components/DashboardNav.tsx
+++ b/src/components/DashboardNav.tsx
@@ -28,12 +28,29 @@ const DashboardNav = () => {
       <div className="container flex h-16 items-center justify-between">
         <div className="flex items-center gap-6">
           <button
-            className="flex items-center gap-2 focus:outline-none"
+            type="button"
+            className="flex items-center gap-2 rounded-md focus:outline-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
             onClick={() => {
               if (location.pathname === "/dashboard") {
                 window.scrollTo({ top: 0, behavior: "smooth" });
               } else {
                 navigate("/dashboard");
+                requestAnimationFrame(() => {
+                  window.scrollTo({ top: 0, behavior: "smooth" });
+                });
+              }
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                if (location.pathname === "/dashboard") {
+                  window.scrollTo({ top: 0, behavior: "smooth" });
+                } else {
+                  navigate("/dashboard");
+                  requestAnimationFrame(() => {
+                    window.scrollTo({ top: 0, behavior: "smooth" });
+                  });
+                }
               }
             }}
           >

--- a/src/components/DashboardNav.tsx
+++ b/src/components/DashboardNav.tsx
@@ -27,10 +27,19 @@ const DashboardNav = () => {
     <nav className="sticky top-0 z-50 border-b border-border/50 bg-background/80 backdrop-blur-xl">
       <div className="container flex h-16 items-center justify-between">
         <div className="flex items-center gap-6">
-          <Link to="/dashboard" className="flex items-center gap-2">
+          <button
+            className="flex items-center gap-2 focus:outline-none"
+            onClick={() => {
+              if (location.pathname === "/dashboard") {
+                window.scrollTo({ top: 0, behavior: "smooth" });
+              } else {
+                navigate("/dashboard");
+              }
+            }}
+          >
             <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-primary text-primary-foreground font-display font-bold text-lg">F</div>
             <span className="font-display font-bold text-xl text-foreground hidden sm:inline">FiscalAura</span>
-          </Link>
+          </button>
           <div className="hidden md:flex items-center gap-1">
             {navItems.map((item) => (
               <Link key={item.path} to={item.path}>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -39,7 +39,12 @@ const Index = () => {
         className="fixed top-0 left-0 right-0 z-50 px-6 py-4"
       >
         <div className="max-w-7xl mx-auto glass rounded-full px-8 py-3 flex items-center justify-between border-white/10 shadow-2xl backdrop-blur-2xl">
-          <div className="flex items-center gap-2 group cursor-pointer" onClick={() => navigate("/")}>
+          <div
+            className="flex items-center gap-2 group cursor-pointer"
+            onClick={() => {
+              window.scrollTo({ top: 0, behavior: "smooth" });
+            }}
+          >
             <div className="p-2 rounded-xl bg-primary shadow-lg shadow-primary/30 group-hover:rotate-12 transition-transform">
               <Sparkles className="h-5 w-5 text-white" />
             </div>


### PR DESCRIPTION
## Summary

Fixes #4 — Implements smooth scroll-to-top behavior when the FiscalAura logo is clicked in the navbar.

---

## Problem

- Clicking the logo in `Index.tsx` called `navigate("/")`, causing a React Router re-navigation even when already on the homepage — leading to a page jump/reload effect.
- The logo in `DashboardNav.tsx` used `<Link to="/dashboard">` with no scroll-to-top behavior.

---

## Changes Made

### `src/pages/Index.tsx`
- Replaced `onClick={() => navigate("/")}` with `window.scrollTo({ top: 0, behavior: "smooth" })`
- Logo now smoothly scrolls to top — no re-navigation, no page jump

### `src/components/DashboardNav.tsx`
- Replaced `<Link to="/dashboard">` with a `<button>` + click handler
- If already on `/dashboard` → smoothly scrolls to top
- If on any other page → navigates to `/dashboard`

---

## Behavior After Fix

| Scenario | Result |
|---|---|
| On homepage, click logo | ✅ Smooth scroll to top |
| On dashboard, click logo | ✅ Smooth scroll to top |
| On another page, click logo | ✅ Navigates to dashboard |
| Already at top, click logo | ✅ No visible disruption |

---

## Type of Change
- [x] Bug fix
- [x] UX improvement

## Checklist
- [x] Follows existing code style
- [x] No unnecessary re-renders or navigation side effects
- [x] Uses native `window.scrollTo` with `behavior: "smooth"`
- [x] Works on both landing page navbar and dashboard navbar
